### PR TITLE
Remove plugin bluetoothsetup-gb7252 from gb7252 image

### DIFF
--- a/conf/machine/include/gigablue-gb7252.inc
+++ b/conf/machine/include/gigablue-gb7252.inc
@@ -52,10 +52,6 @@ EXTRA_IMAGEDEPENDS = "\
     gigablue-initrd-cfe-${MACHINE} \
     "
 
-IMAGE_INSTALL_append += "\
-    bluetoothsetup-gb7252 \
-    "
-
 OPTIONAL_BSP_ENIGMA2_PACKAGES = "\
     enigma2-plugin-extensions-hbbtv-gb \
     enigma2-plugin-extensions-chromium \


### PR DESCRIPTION
In the plugin is used the closed-source c library _gbbt, which is not compatible with python3, so the plugin does not work because it calls GSOD when strating:
ImportError: dynamic module does not define module export function (PyInit__gbbt)